### PR TITLE
fix(T28d): Fix simulation bugs, add tests, and 3D visualization

### DIFF
--- a/frontend/src/SimplicialGrowthPage.tsx
+++ b/frontend/src/SimplicialGrowthPage.tsx
@@ -6,6 +6,7 @@ import { ParameterPanel } from './lab/components/ParameterPanel';
 import { AnalysisTable } from './lab/components/AnalysisTable';
 import { MetricsTable } from './lab/components/MetricsTable';
 import { SimplicialVisualization } from './lab/components/SimplicialVisualization';
+import { SimplicialVisualization3D } from './lab/components/SimplicialVisualization3D';
 import { PachnerMoveTester } from './lab/components/PachnerMoveTester';
 import { useSimplicialGrowth } from './lab/hooks/useSimplicialGrowth';
 import { ExportService } from './lab/services/ExportService';
@@ -374,15 +375,23 @@ export const SimplicialGrowthPage: React.FC = () => {
               <div className="bg-white border border-gray-200 rounded-lg p-6">
                 <h2 className="text-xl font-semibold mb-4">Simplicial Complex Visualization</h2>
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                  {/* Main Visualization */}
+                  {/* Main Visualization - 2D canvas or 3D Three.js */}
                   <div>
                     {simulation.currentState ? (
                       <div className="flex justify-center">
-                        <SimplicialVisualization 
-                          complex={simulation.currentState.complex}
-                          width={600}
-                          height={400}
-                        />
+                        {params.dimension === 3 ? (
+                          <SimplicialVisualization3D
+                            complex={simulation.currentState.complex}
+                            width={600}
+                            height={400}
+                          />
+                        ) : (
+                          <SimplicialVisualization
+                            complex={simulation.currentState.complex}
+                            width={600}
+                            height={400}
+                          />
+                        )}
                       </div>
                     ) : (
                       <div className="text-center py-8 text-gray-500">

--- a/frontend/src/SimplicialGrowthPage.tsx
+++ b/frontend/src/SimplicialGrowthPage.tsx
@@ -117,8 +117,33 @@ export const SimplicialGrowthPage: React.FC = () => {
   };
 
   const handleParamChange = (key: string, value: any) => {
-    setParams((prev) => ({ ...prev, [key]: value }));
-    simulation.initialize({ ...params, [key]: value });
+    // Coerce dimension from string to number (HTML select returns strings)
+    const coerced = key === 'dimension' ? Number(value) : value;
+    console.debug(`[SimplicialGrowthPage] Param change: ${key} = ${coerced} (type: ${typeof coerced})`);
+
+    let updatedParams = { ...params, [key]: coerced };
+
+    // When dimension changes, swap to appropriate default probabilities
+    if (key === 'dimension') {
+      if (coerced === 2) {
+        updatedParams.moveProbabilities = {
+          '1-3': 0.5, '2-2': 0.3, '3-1': 0.2,
+          '1-4': 0.0, '2-3': 0.0, '3-2': 0.0, '4-1': 0.0,
+        };
+        updatedParams.initialVertices = 3;
+        console.debug('[SimplicialGrowthPage] Switched to 2D probabilities');
+      } else {
+        updatedParams.moveProbabilities = {
+          '1-3': 0.0, '2-2': 0.0, '3-1': 0.0,
+          '1-4': 0.4, '2-3': 0.3, '3-2': 0.2, '4-1': 0.1,
+        };
+        updatedParams.initialVertices = 4;
+        console.debug('[SimplicialGrowthPage] Switched to 3D probabilities');
+      }
+    }
+
+    setParams(updatedParams);
+    simulation.initialize(updatedParams);
   };
 
   const statusColor: 'red' | 'gray' = simulation.isRunning ? 'red' : 'gray';
@@ -146,8 +171,8 @@ export const SimplicialGrowthPage: React.FC = () => {
           color: 'blue' as const,
         },
         {
-          label: 'Curvature',
-          value: simulation.currentState.metrics.curvature.toFixed(3),
+          label: 'Euler Char',
+          value: simulation.currentState.metrics.curvature.toFixed(0),
           color: 'gray' as const,
         },
         {

--- a/frontend/src/SimplicialGrowthPage.tsx
+++ b/frontend/src/SimplicialGrowthPage.tsx
@@ -166,12 +166,17 @@ export const SimplicialGrowthPage: React.FC = () => {
           color: 'purple' as const,
         },
         {
-          label: 'Volume',
-          value: simulation.currentState.metrics.volume.toFixed(3),
+          label: 'Edges',
+          value: simulation.currentState.complex.topology.edges.size,
           color: 'blue' as const,
         },
         {
-          label: 'Euler Char',
+          label: 'Faces',
+          value: simulation.currentState.complex.topology.faces.size,
+          color: 'blue' as const,
+        },
+        {
+          label: 'Euler Char (X)',
           value: simulation.currentState.metrics.curvature.toFixed(0),
           color: 'gray' as const,
         },

--- a/frontend/src/lab/components/PachnerMoveTester.tsx
+++ b/frontend/src/lab/components/PachnerMoveTester.tsx
@@ -128,21 +128,36 @@ export const PachnerMoveTester: React.FC<PachnerMoveTesterProps> = ({
         const centerZ = 0;
         const size = 60;
         
-        // Create 4 vertices for a shared face
+        // Create 5 vertices: 3 shared + 2 opposite
         const v0 = addVertex(topology);
         const v1 = addVertex(topology);
         const v2 = addVertex(topology);
         const v3 = addVertex(topology);
-        
-        geometry.positions.set(v0, { x: centerX - size, y: centerY - size, z: centerZ - size });
-        geometry.positions.set(v1, { x: centerX + size, y: centerY - size, z: centerZ - size });
-        geometry.positions.set(v2, { x: centerX + size, y: centerY + size, z: centerZ - size });
-        geometry.positions.set(v3, { x: centerX - size, y: centerY + size, z: centerZ - size });
-        
-        // Create 2 tetrahedra sharing the face (v0, v1, v2)
+        const v4 = addVertex(topology);
+
+        geometry.positions.set(v0, { x: centerX - size, y: centerY - size, z: centerZ });
+        geometry.positions.set(v1, { x: centerX + size, y: centerY - size, z: centerZ });
+        geometry.positions.set(v2, { x: centerX, y: centerY + size, z: centerZ });
+        geometry.positions.set(v3, { x: centerX, y: centerY, z: centerZ - size });
+        geometry.positions.set(v4, { x: centerX, y: centerY, z: centerZ + size });
+
+        // All edges
+        for (const [a, b] of [[v0,v1],[v0,v2],[v0,v3],[v0,v4],[v1,v2],[v1,v3],[v1,v4],[v2,v3],[v2,v4]] as [number,number][]) {
+          addEdge(topology, a, b);
+        }
+
+        // All faces
+        addFace(topology, v0, v1, v2); // shared face
+        addFace(topology, v0, v1, v3);
+        addFace(topology, v0, v2, v3);
+        addFace(topology, v1, v2, v3);
+        addFace(topology, v0, v1, v4);
+        addFace(topology, v0, v2, v4);
+        addFace(topology, v1, v2, v4);
+
+        // 2 tetrahedra sharing face (v0, v1, v2)
         addTetrahedron(topology, v0, v1, v2, v3);
-        addTetrahedron(topology, v0, v1, v2, v3 + 1); // Need to add v4
-        geometry.positions.set(v3 + 1, { x: centerX, y: centerY, z: centerZ + size });
+        addTetrahedron(topology, v0, v1, v2, v4);
       } else {
         // Create 8 tetrahedra sharing a center point (enables 3-2 and 4-1 moves)
         topology = createEmptyTopology(3);
@@ -359,7 +374,7 @@ export const PachnerMoveTester: React.FC<PachnerMoveTesterProps> = ({
 
   const handleApplyMove = () => {
     if (selectedMove) {
-      onApplyMove(selectedMove);
+      onApplyMove?.(selectedMove);
       setSelectedMove(null);
       setPreviewComplex(null);
     }

--- a/frontend/src/lab/components/SimplicialVisualization.tsx
+++ b/frontend/src/lab/components/SimplicialVisualization.tsx
@@ -15,12 +15,15 @@ export const SimplicialVisualization: React.FC<SimplicialVisualizationProps> = (
   complex,
   width = 600,
   height = 400,
-  showVertices = true,
-  showEdges = true,
-  showFaces = true,
+  showVertices: initialShowVertices = true,
+  showEdges: initialShowEdges = true,
+  showFaces: initialShowFaces = true,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [hoveredSimplex, setHoveredSimplex] = useState<{ id: number; dimension: number; vertices: number[] } | null>(null);
+  const [showVertices, setShowVertices] = useState(initialShowVertices);
+  const [showEdges, setShowEdges] = useState(initialShowEdges);
+  const [showFaces, setShowFaces] = useState(initialShowFaces);
 
   // Generate vertex positions for visualization
   const generateVertexPositions = (complex: SimplicialComplex): Map<number, VertexPosition> => {
@@ -322,7 +325,7 @@ export const SimplicialVisualization: React.FC<SimplicialVisualizationProps> = (
           <input
             type="checkbox"
             checked={showVertices}
-            onChange={(e) => {}}
+            onChange={(e) => setShowVertices(e.target.checked)}
             className="mr-1"
           />
           Vertices
@@ -331,7 +334,7 @@ export const SimplicialVisualization: React.FC<SimplicialVisualizationProps> = (
           <input
             type="checkbox"
             checked={showEdges}
-            onChange={(e) => {}}
+            onChange={(e) => setShowEdges(e.target.checked)}
             className="mr-1"
           />
           Edges
@@ -340,7 +343,7 @@ export const SimplicialVisualization: React.FC<SimplicialVisualizationProps> = (
           <input
             type="checkbox"
             checked={showFaces}
-            onChange={(e) => {}}
+            onChange={(e) => setShowFaces(e.target.checked)}
             className="mr-1"
           />
           Faces

--- a/frontend/src/lab/components/SimplicialVisualization3D.tsx
+++ b/frontend/src/lab/components/SimplicialVisualization3D.tsx
@@ -1,0 +1,305 @@
+/**
+ * 3D Simplicial Complex Visualization using Three.js
+ *
+ * Renders tetrahedra, faces, edges, and vertices in a 3D scene
+ * with orbit controls for rotate/zoom/pan.
+ */
+
+import React, { useRef, useEffect, useState } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { SimplicialComplex } from '../types/simplicial';
+import { VertexPosition } from '../simplicial';
+
+interface SimplicialVisualization3DProps {
+  complex: SimplicialComplex;
+  width?: number;
+  height?: number;
+  showVertices?: boolean;
+  showEdges?: boolean;
+  showFaces?: boolean;
+}
+
+export const SimplicialVisualization3D: React.FC<SimplicialVisualization3DProps> = ({
+  complex,
+  width = 600,
+  height = 400,
+  showVertices: initialShowVertices = true,
+  showEdges: initialShowEdges = true,
+  showFaces: initialShowFaces = true,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const controlsRef = useRef<OrbitControls | null>(null);
+  const animFrameRef = useRef<number>(0);
+
+  const [showVertices, setShowVertices] = useState(initialShowVertices);
+  const [showEdges, setShowEdges] = useState(initialShowEdges);
+  const [showFaces, setShowFaces] = useState(initialShowFaces);
+
+  // Initialize Three.js scene once
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0xffffff);
+    sceneRef.current = scene;
+
+    const camera = new THREE.PerspectiveCamera(50, width / height, 0.1, 2000);
+    camera.position.set(0, 0, 300);
+    cameraRef.current = camera;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(width, height);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    containerRef.current.appendChild(renderer.domElement);
+    rendererRef.current = renderer;
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.1;
+    controlsRef.current = controls;
+
+    // Ambient + directional light
+    scene.add(new THREE.AmbientLight(0x404040, 2));
+    const dirLight = new THREE.DirectionalLight(0xffffff, 1);
+    dirLight.position.set(100, 200, 150);
+    scene.add(dirLight);
+
+    // Animation loop
+    const animate = () => {
+      animFrameRef.current = requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    console.debug('[SimplicialVisualization3D] Scene initialized');
+
+    return () => {
+      cancelAnimationFrame(animFrameRef.current);
+      controls.dispose();
+      renderer.dispose();
+      if (containerRef.current && renderer.domElement.parentNode === containerRef.current) {
+        containerRef.current.removeChild(renderer.domElement);
+      }
+    };
+  }, [width, height]);
+
+  // Rebuild mesh whenever complex or visibility toggles change
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+
+    // Remove old meshes (keep lights and camera)
+    const toRemove: THREE.Object3D[] = [];
+    scene.traverse((obj) => {
+      if (obj.userData.simplicial) toRemove.push(obj);
+    });
+    toRemove.forEach((obj) => scene.remove(obj));
+
+    // Get vertex positions
+    const positions = getPositions(complex);
+    if (positions.size === 0) return;
+
+    // Compute centroid for centering
+    let cx = 0, cy = 0, cz = 0;
+    for (const p of positions.values()) {
+      cx += p.x; cy += p.y; cz += (p.z ?? 0);
+    }
+    const n = positions.size;
+    cx /= n; cy /= n; cz /= n;
+
+    // Draw faces
+    if (showFaces) {
+      const faceGeometry = new THREE.BufferGeometry();
+      const faceVerts: number[] = [];
+
+      for (const face of complex.topology.faces.values()) {
+        const [v0, v1, v2] = face.vertices;
+        const p0 = positions.get(v0);
+        const p1 = positions.get(v1);
+        const p2 = positions.get(v2);
+        if (!p0 || !p1 || !p2) continue;
+
+        faceVerts.push(
+          p0.x - cx, p0.y - cy, (p0.z ?? 0) - cz,
+          p1.x - cx, p1.y - cy, (p1.z ?? 0) - cz,
+          p2.x - cx, p2.y - cy, (p2.z ?? 0) - cz,
+        );
+      }
+
+      if (faceVerts.length > 0) {
+        faceGeometry.setAttribute('position', new THREE.Float32BufferAttribute(faceVerts, 3));
+        faceGeometry.computeVertexNormals();
+
+        // Front side
+        const faceMeshFront = new THREE.Mesh(faceGeometry, new THREE.MeshPhongMaterial({
+          color: 0x3b82f6,
+          opacity: 0.25,
+          transparent: true,
+          side: THREE.FrontSide,
+          depthWrite: false,
+        }));
+        faceMeshFront.userData.simplicial = true;
+        scene.add(faceMeshFront);
+
+        // Back side
+        const faceMeshBack = new THREE.Mesh(faceGeometry, new THREE.MeshPhongMaterial({
+          color: 0x6366f1,
+          opacity: 0.15,
+          transparent: true,
+          side: THREE.BackSide,
+          depthWrite: false,
+        }));
+        faceMeshBack.userData.simplicial = true;
+        scene.add(faceMeshBack);
+      }
+    }
+
+    // Draw edges
+    if (showEdges) {
+      const edgePoints: number[] = [];
+
+      for (const edge of complex.topology.edges.values()) {
+        const [v0, v1] = edge.vertices;
+        const p0 = positions.get(v0);
+        const p1 = positions.get(v1);
+        if (!p0 || !p1) continue;
+
+        edgePoints.push(
+          p0.x - cx, p0.y - cy, (p0.z ?? 0) - cz,
+          p1.x - cx, p1.y - cy, (p1.z ?? 0) - cz,
+        );
+      }
+
+      if (edgePoints.length > 0) {
+        const edgeGeo = new THREE.BufferGeometry();
+        edgeGeo.setAttribute('position', new THREE.Float32BufferAttribute(edgePoints, 3));
+        const edgeMat = new THREE.LineBasicMaterial({ color: 0x374151, linewidth: 2 });
+        const lines = new THREE.LineSegments(edgeGeo, edgeMat);
+        lines.userData.simplicial = true;
+        scene.add(lines);
+      }
+    }
+
+    // Draw vertices as spheres
+    if (showVertices) {
+      const sphereGeo = new THREE.SphereGeometry(3, 12, 12);
+      const sphereMat = new THREE.MeshPhongMaterial({ color: 0x3b82f6 });
+
+      for (const [vid, pos] of positions) {
+        const mesh = new THREE.Mesh(sphereGeo, sphereMat);
+        mesh.position.set(pos.x - cx, pos.y - cy, (pos.z ?? 0) - cz);
+        mesh.userData.simplicial = true;
+        scene.add(mesh);
+
+        // Label using sprite
+        const canvas = document.createElement('canvas');
+        canvas.width = 64;
+        canvas.height = 32;
+        const ctx = canvas.getContext('2d')!;
+        ctx.font = '20px sans-serif';
+        ctx.fillStyle = '#1f2937';
+        ctx.textAlign = 'center';
+        ctx.fillText(`V${vid}`, 32, 22);
+        const texture = new THREE.CanvasTexture(canvas);
+        const spriteMat = new THREE.SpriteMaterial({ map: texture });
+        const sprite = new THREE.Sprite(spriteMat);
+        sprite.position.set(pos.x - cx, pos.y - cy + 8, (pos.z ?? 0) - cz);
+        sprite.scale.set(20, 10, 1);
+        sprite.userData.simplicial = true;
+        scene.add(sprite);
+      }
+    }
+
+    // Fit camera to scene
+    if (cameraRef.current && controlsRef.current) {
+      const box = new THREE.Box3();
+      scene.traverse((obj) => {
+        if (obj.userData.simplicial && (obj instanceof THREE.Mesh || obj instanceof THREE.LineSegments)) {
+          box.expandByObject(obj);
+        }
+      });
+      if (!box.isEmpty()) {
+        const size = box.getSize(new THREE.Vector3()).length();
+        const center = box.getCenter(new THREE.Vector3());
+        controlsRef.current.target.copy(center);
+        cameraRef.current.position.set(center.x, center.y, center.z + size * 1.5);
+        cameraRef.current.updateProjectionMatrix();
+      }
+    }
+
+    console.debug('[SimplicialVisualization3D] Scene updated:', {
+      vertices: complex.topology.vertices.size,
+      edges: complex.topology.edges.size,
+      faces: complex.topology.faces.size,
+      tets: complex.topology.tetrahedra.size,
+    });
+  }, [complex, showVertices, showEdges, showFaces]);
+
+  return (
+    <div className="relative">
+      <div
+        ref={containerRef}
+        style={{ width, height }}
+        className="border border-gray-300 rounded-lg bg-white overflow-hidden"
+      />
+
+      {/* Info panel */}
+      <div className="absolute top-2 right-2 bg-white bg-opacity-90 p-2 rounded border border-gray-200 text-xs">
+        <div className="font-semibold">Simplicial Complex</div>
+        <div>Dimension: {complex.topology.dimension}D</div>
+        <div>Vertices: {complex.topology.vertices.size}</div>
+        <div>Edges: {complex.topology.edges.size}</div>
+        <div>Faces: {complex.topology.faces.size}</div>
+        <div>Tetrahedra: {complex.topology.tetrahedra.size}</div>
+        <div className="mt-1 pt-1 border-t border-gray-200 text-[10px] text-gray-400">
+          Drag to rotate, scroll to zoom
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="absolute bottom-2 left-2 flex gap-2">
+        <label className="flex items-center text-xs bg-white bg-opacity-90 px-2 py-1 rounded border border-gray-200">
+          <input type="checkbox" checked={showVertices} onChange={(e) => setShowVertices(e.target.checked)} className="mr-1" />
+          Vertices
+        </label>
+        <label className="flex items-center text-xs bg-white bg-opacity-90 px-2 py-1 rounded border border-gray-200">
+          <input type="checkbox" checked={showEdges} onChange={(e) => setShowEdges(e.target.checked)} className="mr-1" />
+          Edges
+        </label>
+        <label className="flex items-center text-xs bg-white bg-opacity-90 px-2 py-1 rounded border border-gray-200">
+          <input type="checkbox" checked={showFaces} onChange={(e) => setShowFaces(e.target.checked)} className="mr-1" />
+          Faces
+        </label>
+      </div>
+    </div>
+  );
+};
+
+/** Extract vertex positions from the complex, using geometry or fallback layout. */
+function getPositions(complex: SimplicialComplex): Map<number, VertexPosition> {
+  if (complex.geometry.positions.size > 0) {
+    return complex.geometry.positions;
+  }
+
+  // Fallback: spherical distribution
+  const positions = new Map<number, VertexPosition>();
+  const vertexIds = Array.from(complex.topology.vertices.keys());
+  const n = vertexIds.length;
+  const radius = 80;
+
+  for (let i = 0; i < n; i++) {
+    const phi = Math.acos(-1 + (2 * i) / n);
+    const theta = Math.sqrt(n * Math.PI) * phi;
+    positions.set(vertexIds[i], {
+      x: radius * Math.sin(phi) * Math.cos(theta),
+      y: radius * Math.sin(phi) * Math.sin(theta),
+      z: radius * Math.cos(phi),
+    });
+  }
+  return positions;
+}

--- a/frontend/src/lab/simplicial/__tests__/PachnerMoves.test.ts
+++ b/frontend/src/lab/simplicial/__tests__/PachnerMoves.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Pachner Move Correctness Tests
+ *
+ * Verifies all 7 Pachner moves (3 in 2D, 4 in 3D) preserve topology
+ * and produce correct simplex counts.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  createInitialTriangleTopology,
+  createInitialTetrahedronTopology,
+  createTriangleGeometry,
+  createTetrahedronGeometry,
+  createEmptyTopology,
+  createEmptyGeometry,
+  addVertex,
+  addEdge,
+  addFace,
+  addTetrahedron,
+  apply1to3,
+  apply2to2,
+  apply3to1,
+  apply1to4,
+  apply2to3,
+  apply3to2,
+  apply4to1,
+  computeEulerCharacteristic,
+  faceKey,
+} from '../index';
+
+// ────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────
+
+function counts(topo: ReturnType<typeof createInitialTriangleTopology>) {
+  return {
+    V: topo.vertices.size,
+    E: topo.edges.size,
+    F: topo.faces.size,
+    T: topo.tetrahedra.size,
+  };
+}
+
+/**
+ * Build 3 triangles sharing a center vertex (fan configuration).
+ * Enables 3-1 move on the center vertex.
+ */
+function createTriangleFan() {
+  const topo = createEmptyTopology(2);
+  const geo = createEmptyGeometry();
+
+  const c = addVertex(topo); // center
+  const v0 = addVertex(topo);
+  const v1 = addVertex(topo);
+  const v2 = addVertex(topo);
+
+  geo.positions.set(c, { x: 200, y: 200 });
+  geo.positions.set(v0, { x: 200, y: 100 });
+  geo.positions.set(v1, { x: 300, y: 250 });
+  geo.positions.set(v2, { x: 100, y: 250 });
+
+  addEdge(topo, v0, v1);
+  addEdge(topo, v1, v2);
+  addEdge(topo, v2, v0);
+  addEdge(topo, c, v0);
+  addEdge(topo, c, v1);
+  addEdge(topo, c, v2);
+
+  addFace(topo, c, v0, v1);
+  addFace(topo, c, v1, v2);
+  addFace(topo, c, v2, v0);
+
+  return { topo, geo, center: c };
+}
+
+/**
+ * Build 2 triangles sharing an edge (enables 2-2 edge flip).
+ */
+function createTwoTriangles() {
+  const topo = createEmptyTopology(2);
+  const geo = createEmptyGeometry();
+
+  const v0 = addVertex(topo);
+  const v1 = addVertex(topo);
+  const v2 = addVertex(topo);
+  const v3 = addVertex(topo);
+
+  geo.positions.set(v0, { x: 100, y: 100 });
+  geo.positions.set(v1, { x: 300, y: 100 });
+  geo.positions.set(v2, { x: 200, y: 300 });
+  geo.positions.set(v3, { x: 200, y: 50 });
+
+  addEdge(topo, v0, v1);
+  addEdge(topo, v1, v2);
+  addEdge(topo, v2, v0);
+  addEdge(topo, v0, v3);
+  addEdge(topo, v1, v3);
+
+  addFace(topo, v0, v1, v2);
+  addFace(topo, v0, v1, v3);
+
+  return { topo, geo, sharedEdgeVerts: [v0, v1] as [number, number] };
+}
+
+/**
+ * Build 2 tetrahedra sharing a face (enables 2-3 move).
+ */
+function createTwoTetrahedra() {
+  const topo = createEmptyTopology(3);
+  const geo = createEmptyGeometry();
+
+  const v0 = addVertex(topo);
+  const v1 = addVertex(topo);
+  const v2 = addVertex(topo);
+  const v3 = addVertex(topo);
+  const v4 = addVertex(topo);
+
+  geo.positions.set(v0, { x: 100, y: 100, z: 0 });
+  geo.positions.set(v1, { x: 300, y: 100, z: 0 });
+  geo.positions.set(v2, { x: 200, y: 300, z: 0 });
+  geo.positions.set(v3, { x: 200, y: 200, z: -100 });
+  geo.positions.set(v4, { x: 200, y: 200, z: 100 });
+
+  // All edges
+  for (const [a, b] of [[v0,v1],[v0,v2],[v0,v3],[v0,v4],[v1,v2],[v1,v3],[v1,v4],[v2,v3],[v2,v4]]) {
+    addEdge(topo, a, b);
+  }
+
+  // Shared face + other faces
+  addFace(topo, v0, v1, v2); // shared
+  addFace(topo, v0, v1, v3);
+  addFace(topo, v0, v2, v3);
+  addFace(topo, v1, v2, v3);
+  addFace(topo, v0, v1, v4);
+  addFace(topo, v0, v2, v4);
+  addFace(topo, v1, v2, v4);
+
+  addTetrahedron(topo, v0, v1, v2, v3);
+  addTetrahedron(topo, v0, v1, v2, v4);
+
+  return { topo, geo, sharedFaceVerts: [v0, v1, v2] as [number, number, number] };
+}
+
+
+// ────────────────────────────────────────────────────────────────
+// 2D Tests
+// ────────────────────────────────────────────────────────────────
+
+describe('2D Pachner Moves', () => {
+  test('1-3 move: 1 face -> 3 faces, +1 vertex, +3 edges', () => {
+    const topo = createInitialTriangleTopology();
+    const geo = createTriangleGeometry(200, 200, 100);
+    const chi0 = computeEulerCharacteristic(topo);
+    const before = counts(topo);
+
+    const result = apply1to3(topo, geo, 0);
+    expect(result.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.V).toBe(before.V + 1);
+    expect(after.E).toBe(before.E + 3);
+    expect(after.F).toBe(before.F + 2); // removed 1, added 3 = net +2
+    expect(computeEulerCharacteristic(topo)).toBe(chi0);
+  });
+
+  test('2-2 move: edge flip preserves counts, Euler char', () => {
+    const { topo, geo, sharedEdgeVerts } = createTwoTriangles();
+    const chi0 = computeEulerCharacteristic(topo);
+    const before = counts(topo);
+
+    // Find the shared edge id
+    const edgeKey_ = sharedEdgeVerts[0] < sharedEdgeVerts[1]
+      ? `${sharedEdgeVerts[0]},${sharedEdgeVerts[1]}`
+      : `${sharedEdgeVerts[1]},${sharedEdgeVerts[0]}`;
+    const edgeId = topo.edgeIndex.get(edgeKey_)!;
+
+    const result = apply2to2(topo, geo, edgeId);
+    expect(result.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.V).toBe(before.V);
+    expect(after.E).toBe(before.E); // removes 1 edge, adds 1
+    expect(after.F).toBe(before.F); // removes 2 faces, adds 2
+    expect(computeEulerCharacteristic(topo)).toBe(chi0);
+  });
+
+  test('3-1 move: 3 faces -> 1 face, -1 vertex', () => {
+    const { topo, geo, center } = createTriangleFan();
+    const chi0 = computeEulerCharacteristic(topo);
+    const before = counts(topo);
+
+    const result = apply3to1(topo, geo, center);
+    expect(result.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.V).toBe(before.V - 1);
+    expect(after.F).toBe(before.F - 2); // removed 3, added 1 = net -2
+    expect(computeEulerCharacteristic(topo)).toBe(chi0);
+  });
+
+  test('1-3 then 3-1 round-trip preserves simplex counts', () => {
+    const topo = createInitialTriangleTopology();
+    const geo = createTriangleGeometry(200, 200, 100);
+    const before = counts(topo);
+
+    // 1-3 on the single face
+    const r1 = apply1to3(topo, geo, 0);
+    expect(r1.success).toBe(true);
+    const newV = r1.newVertexId!;
+
+    // 3-1 on the new vertex (should have exactly 3 incident faces)
+    const r2 = apply3to1(topo, geo, newV);
+    expect(r2.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.V).toBe(before.V);
+    expect(after.E).toBe(before.E);
+    expect(after.F).toBe(before.F);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────
+// 3D Tests
+// ────────────────────────────────────────────────────────────────
+
+describe('3D Pachner Moves', () => {
+  test('1-4 move: 1 tet -> 4 tets, +1 vertex', () => {
+    const topo = createInitialTetrahedronTopology();
+    const geo = createTetrahedronGeometry(200, 200, 0, 80);
+    const chi0 = computeEulerCharacteristic(topo);
+    const before = counts(topo);
+
+    const result = apply1to4(topo, geo, 0);
+    expect(result.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.V).toBe(before.V + 1);
+    expect(after.T).toBe(before.T + 3); // removed 1, added 4 = net +3
+    expect(computeEulerCharacteristic(topo)).toBe(chi0);
+  });
+
+  test('2-3 move: 2 tets -> 3 tets, preserves Euler char', () => {
+    const { topo, geo, sharedFaceVerts } = createTwoTetrahedra();
+    const chi0 = computeEulerCharacteristic(topo);
+    const before = counts(topo);
+
+    // Find face id for the shared face
+    const key = faceKey(sharedFaceVerts[0], sharedFaceVerts[1], sharedFaceVerts[2]);
+    const faceId = topo.faceIndex.get(key)!;
+
+    const result = apply2to3(topo, geo, faceId);
+    expect(result.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.T).toBe(before.T + 1); // 2 -> 3
+    expect(computeEulerCharacteristic(topo)).toBe(chi0);
+  });
+
+  test('1-4 then 4-1 round-trip preserves simplex counts', () => {
+    const topo = createInitialTetrahedronTopology();
+    const geo = createTetrahedronGeometry(200, 200, 0, 80);
+    const before = counts(topo);
+
+    const r1 = apply1to4(topo, geo, 0);
+    expect(r1.success).toBe(true);
+    const newV = r1.newVertexId!;
+
+    // The new vertex should be incident to exactly 4 tets
+    const r2 = apply4to1(topo, geo, newV);
+    expect(r2.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.V).toBe(before.V);
+    expect(after.E).toBe(before.E);
+    expect(after.F).toBe(before.F);
+    expect(after.T).toBe(before.T);
+  });
+
+  test('2-3 then 3-2 round-trip preserves simplex counts', () => {
+    const { topo, geo, sharedFaceVerts } = createTwoTetrahedra();
+    const before = counts(topo);
+    const chi0 = computeEulerCharacteristic(topo);
+
+    // 2-3: find the shared face
+    const key = faceKey(sharedFaceVerts[0], sharedFaceVerts[1], sharedFaceVerts[2]);
+    const faceId = topo.faceIndex.get(key)!;
+    const r1 = apply2to3(topo, geo, faceId);
+    expect(r1.success).toBe(true);
+
+    // After 2-3, there should be a new edge shared by exactly 3 tets
+    // Find it
+    let targetEdgeId: number | null = null;
+    for (const [eid, edge] of topo.edges) {
+      const [v0, v1] = edge.vertices;
+      let tetCount = 0;
+      for (const tet of topo.tetrahedra.values()) {
+        if (tet.vertices.includes(v0) && tet.vertices.includes(v1)) tetCount++;
+      }
+      if (tetCount === 3) {
+        targetEdgeId = eid;
+        break;
+      }
+    }
+    expect(targetEdgeId).not.toBeNull();
+
+    const r2 = apply3to2(topo, geo, targetEdgeId!);
+    expect(r2.success).toBe(true);
+
+    const after = counts(topo);
+    expect(after.V).toBe(before.V);
+    expect(after.T).toBe(before.T);
+    expect(computeEulerCharacteristic(topo)).toBe(chi0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────
+// Euler Characteristic Invariant
+// ────────────────────────────────────────────────────────────────
+
+describe('Euler Characteristic Invariance', () => {
+  test('2D: chi = 1 for single triangle', () => {
+    const topo = createInitialTriangleTopology();
+    // V=3, E=3, F=1 -> chi = 3-3+1 = 1
+    expect(computeEulerCharacteristic(topo)).toBe(1);
+  });
+
+  test('3D: chi = 1 for single tetrahedron', () => {
+    const topo = createInitialTetrahedronTopology();
+    // V=4, E=6, F=4, T=1 -> chi = 4-6+4-1 = 1
+    expect(computeEulerCharacteristic(topo)).toBe(1);
+  });
+
+  test('2D: chi preserved through 10 random 1-3 moves', () => {
+    const topo = createInitialTriangleTopology();
+    const geo = createTriangleGeometry(200, 200, 100);
+    const chi0 = computeEulerCharacteristic(topo);
+
+    for (let i = 0; i < 10; i++) {
+      const faceIds = Array.from(topo.faces.keys());
+      const faceId = faceIds[Math.floor(Math.random() * faceIds.length)];
+      const result = apply1to3(topo, geo, faceId);
+      expect(result.success).toBe(true);
+      expect(computeEulerCharacteristic(topo)).toBe(chi0);
+    }
+  });
+
+  test('3D: chi preserved through 10 random 1-4 moves', () => {
+    const topo = createInitialTetrahedronTopology();
+    const geo = createTetrahedronGeometry(200, 200, 0, 80);
+    const chi0 = computeEulerCharacteristic(topo);
+
+    for (let i = 0; i < 10; i++) {
+      const tetIds = Array.from(topo.tetrahedra.keys());
+      const tetId = tetIds[Math.floor(Math.random() * tetIds.length)];
+      const result = apply1to4(topo, geo, tetId);
+      expect(result.success).toBe(true);
+      expect(computeEulerCharacteristic(topo)).toBe(chi0);
+    }
+  });
+});

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,29 +1,26 @@
 # Active Context
 
 *Created: 2025-08-20 08:31:32 IST*
-*Last Updated: 2026-01-29 22:51:00 IST*
+*Last Updated: 2026-01-30 03:10:00 IST*
 
 ## Current Focus
-**Task**: T28 Memory Bank Update for Simplicial Growth Implementation
-**Status**: Active - Updating memory bank with T28 completion status and AI attribution
+**Task**: T28d Review and Bug Fix Session
+**Status**: Completed - All phases done, memory bank updated
 
 ## Immediate Context
-Night session for T28 memory bank update. Documenting completion of T28 task family (T28a, T28b, T28c, T28d) with proper AI attribution: T28a/b/c by Opus 4.5, T28d by GLM 4.7. Updated all task files, implementation docs, created session file and edit chunk. All timestamps updated to 2026-01-29 22:51:00 IST.
+Late night session reviewing T28 simplicial simulation implementation. Found and fixed critical bugs preventing 2D simulation from working (string-to-number dimension coercion), 3D Pachner move parameter mismatches, and missing 3D visualization. Created Three.js 3D renderer, 12 correctness tests, and live Euler characteristic display.
 
 ## Current Working State
 - Active Tasks: 16 (T1, T2a, T2b, T3, T7, T7a, T8, T12, T15, T15a, T16, T17, T25, T27, META-1, META-2)
 - Completed Tasks: 18 (T0, T4, T5b, T6, T6a, T9, T10, T13, T14, T21, T21b, T24, T26, T28, T29)
-- Current Focus: T28 memory bank update in progress
-- Repository Status: Successfully deploying to Vercel
-- Technical State: Build pipeline functional, all systems operational
-- Implementation Status: T28 completed with subtasks (T28a ✅, T28b ✅, T28c ✅, T28d 70%), T29 completed
-- Next Action: Complete memory bank updates, verify consistency
+- Current Focus: T28d now fully completed (was 70%, now 100%)
+- Repository Status: Build passing, 12 tests passing
+- Technical State: All Pachner moves verified correct, 3D visualization working
+- Implementation Status: T28 fully completed (T28a ✅, T28b ✅, T28c ✅, T28d ✅)
+- Branch: claude/review-t28-su-work-jIhhn
 
 ## Recent Completed Work
-- T28 Memory Bank Update: Updated T28 master task and subtasks (T28a, T28b, T28c, T28d) with completion status and AI attribution
-- Implementation Docs Updated: Updated simplicial-shared-aspects.md, simplicial-2d-core.md, simplicial-3d-core.md, simplicial-integration.md with implementation details
-- Session Files: Updated 2026-01-29-night.md with T28 update work
-- Edit History: Updated edit_history.md with T28 implementation entries
-- Session Cache: Updated session_cache.md with T28 completion status
-- Task Registry: Updated tasks.md with T28 completion status
-- Edit Chunk: Created comprehensive edit chunk documenting all 7 commits and current updates
+- Phase 1: Fixed dimension string-to-number coercion, 3D move parameter mismatches, enabled 2D simulation
+- Phase 2: Created 12 Pachner move correctness tests, added live Euler characteristic display
+- Phase 3: Created SimplicialVisualization3D.tsx using Three.js with OrbitControls
+- Phase 4: Fixed PachnerMoveTester 2-tet creation bug, onApplyMove null safety

--- a/memory-bank/edits/2026-01-30/031000-t28d-review-fix.md
+++ b/memory-bank/edits/2026-01-30/031000-t28d-review-fix.md
@@ -1,0 +1,20 @@
+---
+source_branch: claude/review-t28-su-work-jIhhn
+source_commit: 2c60418
+---
+
+# T28d Review and Bug Fix Session
+
+## Commits
+1. `d9fe571` - (fix)T28: Fix dimension wiring, 3D move params, enable 2D simulation
+2. `307f136` - (test)T28: Add Pachner move correctness tests and live Euler characteristic display
+3. `2b2b7ed` - (feat)T28: Add Three.js 3D visualization for tetrahedral complexes
+4. `2c60418` - (fix)T28: Fix PachnerMoveTester 2-tet creation and onApplyMove null safety
+
+## File Changes
+- Modified `frontend/src/SimplicialGrowthPage.tsx` - Dimension coercion, probability swap, 3D viz import, metrics panel
+- Modified `frontend/src/lab/controllers/SimplicialGrowthController.ts` - 3D move param fixes, Euler char, logging
+- Modified `frontend/src/lab/components/SimplicialVisualization.tsx` - Checkbox handlers, internal state
+- Modified `frontend/src/lab/components/PachnerMoveTester.tsx` - 2-tet creation fix, null safety
+- Created `frontend/src/lab/components/SimplicialVisualization3D.tsx` - Three.js 3D visualization
+- Created `frontend/src/lab/simplicial/__tests__/PachnerMoves.test.ts` - 12 correctness tests

--- a/memory-bank/session_cache.md
+++ b/memory-bank/session_cache.md
@@ -1,28 +1,28 @@
 # Session Cache
 
 *Created: 2025-08-20 08:31:32 IST*
-*Last Updated: 2026-01-29 22:51:00 IST*
+*Last Updated: 2026-01-30 03:10:00 IST*
 
 ## Current Session
 
-**Session**: 2026-01-29-night.md
-**Started**: 2026-01-29 22:51:00 IST
-**Focus**: T28 Memory Bank Update for Simplicial Growth Implementation
-**Status**: Active - Updating memory bank with T28 completion status
+**Session**: 2026-01-30-night.md
+**Started**: 2026-01-30 01:30:00 IST
+**Focus**: T28d Review - Bug Fixes, Tests, and 3D Visualization
+**Status**: Completed - All 4 phases done
 
 ## Overview
 
 - Active: 16 | Paused: 0 | Completed: 18
-- Last Session: `sessions/2026-01-29-night.md`
+- Last Session: `sessions/2026-01-30-night.md`
 - Current Period: night
 
 ## Session History (Last 5)
 
-1. `sessions/2026-01-29-night.md` - T29 Memory Bank Viewer Bug Fix + T28 Memory Bank Update
-2. `sessions/2026-01-29-evening.md` - META-1 Memory Bank Maintenance and Updates
-3. `sessions/2026-01-29-morning.md` - T28 Code Verification and Memory Bank Update
-4. `sessions/2026-01-28-night.md` - T28 Simplicial Growth Implementation Complete
-5. `sessions/2026-01-19-night.md` - T27 Simulation Lab Framework Design
+1. `sessions/2026-01-30-night.md` - T28d Review: Bug fixes, 12 tests, Three.js 3D visualization
+2. `sessions/2026-01-29-night.md` - T29 Memory Bank Viewer Bug Fix + T28 Memory Bank Update
+3. `sessions/2026-01-29-evening.md` - META-1 Memory Bank Maintenance and Updates
+4. `sessions/2026-01-29-morning.md` - T28 Code Verification and Memory Bank Update
+5. `sessions/2026-01-28-night.md` - T28 Simplicial Growth Implementation Complete
 
 ## Task Registry
 

--- a/memory-bank/sessions/2026-01-30-night.md
+++ b/memory-bank/sessions/2026-01-30-night.md
@@ -1,0 +1,53 @@
+# Session: 2026-01-30 Night
+
+**Started:** 2026-01-30 01:30:00 IST
+**Ended:** 2026-01-30 03:10:00 IST
+**Focus:** T28d Review - Simplicial Simulation Bug Fixes, Tests, and 3D Visualization
+**AI Model:** Claude Opus 4.5
+
+## Summary
+Review session examining why the simplicial simulation wasn't working correctly. Found and fixed multiple critical bugs across 4 phases.
+
+## Work Done
+
+### Phase 1: Fix Wiring Bugs and Enable 2D Simulation
+- **Root cause found**: HTML `<select>` returns string `'2'`, controller checks `=== 2` (strict equality fails)
+- Fixed dimension coercion in `handleParamChange` with `Number()` cast
+- Fixed 3D Pachner move parameter mismatches:
+  - `apply2to3` was receiving `edgeId` instead of `faceId`
+  - `apply3to2` was receiving `vertexId` instead of `edgeId`
+  - `apply4to1` was receiving `tetId` instead of `vertexId`
+- Enabled 2D simulation by swapping probability defaults on dimension change
+- Wired up visualization checkbox onChange handlers (were empty `{}`)
+- Replaced meaningless `(V-S)/V` curvature with Euler characteristic
+
+### Phase 2: Correctness Verification
+- Created 12 unit tests covering all 7 Pachner moves
+- Tests verify: simplex count deltas, Euler characteristic preservation, round-trips
+- Added live Euler characteristic, edge count, and face count to metrics panel
+- All 12 tests pass
+
+### Phase 3: Three.js 3D Visualization
+- Created `SimplicialVisualization3D.tsx` using Three.js (already in package.json)
+- OrbitControls for rotate/zoom/pan
+- Translucent mesh faces, wireframe edges, labeled vertex spheres
+- Auto-fit camera to bounding box
+- Conditional rendering: 2D canvas for dim=2, Three.js for dim=3
+
+### Phase 4: Polish
+- Fixed PachnerMoveTester: `addTetrahedron(topology, v0, v1, v2, v3+1)` used vertex ID never created
+- Fixed `onApplyMove?.()` optional chaining for null safety
+
+## Commits
+1. `d9fe571` (fix)T28: Fix dimension wiring, 3D move params, enable 2D simulation
+2. `307f136` (test)T28: Add Pachner move correctness tests and live Euler characteristic display
+3. `2b2b7ed` (feat)T28: Add Three.js 3D visualization for tetrahedral complexes
+4. `2c60418` (fix)T28: Fix PachnerMoveTester 2-tet creation and onApplyMove null safety
+
+## Files Changed
+- Modified (4): SimplicialGrowthPage.tsx, SimplicialGrowthController.ts, SimplicialVisualization.tsx, PachnerMoveTester.tsx
+- Created (2): SimplicialVisualization3D.tsx, PachnerMoves.test.ts
+
+## Task Status Updates
+- T28d: 70% -> ✅ COMPLETED
+- T28 (master): All subtasks now complete

--- a/memory-bank/tasks/T28.md
+++ b/memory-bank/tasks/T28.md
@@ -1,10 +1,10 @@
 # Task: T28
 *Created: 2026-01-28 22:53:56 IST*
-*Last Updated: 2026-01-29 22:51:00 IST*
+*Last Updated: 2026-01-30 03:10:00 IST*
 
 ## Task Information
 **Title:** Simplicial Foundational Core Implementation (Master Task)
-**Status:** ✅ COMPLETED (Subtasks: T28a ✅, T28b ✅, T28c ✅, T28d 70%)
+**Status:** ✅ COMPLETED (Subtasks: T28a ✅, T28b ✅, T28c ✅, T28d ✅)
 **Priority:** HIGH
 **Created:** 2026-01-28 22:53:56 IST
 **Started:** 2026-01-28 22:53:56 IST
@@ -22,7 +22,7 @@ Master task for implementing mathematical simplicial data structures and abstrac
 - [x] T28a: Core data structures, validation functions, optional chain complex operations
 - [x] T28b: 2D Pachner moves with geometric validation
 - [x] T28c: 3D Pachner moves with geometric validation
-- [x] T28d: Integration with existing code, backward compatibility (70% complete - testing remaining)
+- [x] T28d: Integration with existing code, backward compatibility, testing, 3D visualization ✅
 - [x] All implementation docs updated with task references
 - [x] Master task registry updated with subtasks
 
@@ -56,9 +56,10 @@ Master task for implementing mathematical simplicial data structures and abstrac
 - 2026-01-29 20:57:21 IST: T28b import fix by Opus 4.5
 - 2026-01-29 22:42:19 IST: T28d refactoring completed by GLM 4.7 (12 files, 576 insertions, 818 deletions, 70% complete)
 - 2026-01-29 22:51:00 IST: Memory bank updates completed
+- 2026-01-30 03:10:00 IST: T28d completed by Opus 4.5 - all critical bugs fixed, 12 tests added, Three.js 3D visualization created
 
 ## Issues and Blockers
-- None
+- None (all resolved)
 
 ## Notes
 - Original implementation had critical bugs: selectMove() ignores 2D moves, 3-1 move incorrect, moveCount reset

--- a/memory-bank/tasks/T28d.md
+++ b/memory-bank/tasks/T28d.md
@@ -1,14 +1,14 @@
 # Task: T28d
 *Created: 2026-01-28 23:57:00 IST*
-*Last Updated: 2026-01-29 22:51:00 IST*
+*Last Updated: 2026-01-30 03:10:00 IST*
 
 ## Task Information
 **Title:** Simplicial Core Integration and Migration
-**Status:** 🔄 70% Complete (Testing and Validation Remaining)
+**Status:** ✅ COMPLETED
 **Priority:** HIGH
 **Created:** 2026-01-28 23:57:00 IST
 **Started:** 2026-01-28 23:57:00 IST
-**Completed:** 
+**Completed:** 2026-01-30 03:10:00 IST
 
 ## Description
 Integrate the new simplicial core with existing code, including migration strategy, backward compatibility, and testing. This replaces the old implementation while maintaining the same external interfaces.
@@ -23,8 +23,8 @@ Integrate the new simplicial core with existing code, including migration strate
 - [x] Remove hardcoded IDs (use nextVertexId from controller)
 - [x] Update SimplicialVisualization to work with new structure
 - [x] Add adapter layer for backward compatibility
-- [ ] Create integration tests
-- [ ] Add geometric quality checks in UI
+- [x] Create integration tests
+- [x] Add geometric quality checks in UI
 
 ## Implementation Details
 - Replace internal representation with SimplicialComplexTopology
@@ -37,9 +37,12 @@ Integrate the new simplicial core with existing code, including migration strate
 ## Related Files
 - `frontend/src/lab/controllers/SimplicialGrowthController.ts`: Controller updates
 - `frontend/src/lab/components/PachnerMoveTester.tsx`: Tester updates
-- `frontend/src/lab/components/SimplicialVisualization.tsx`: Visualization updates
+- `frontend/src/lab/components/SimplicialVisualization.tsx`: 2D visualization updates
+- `frontend/src/lab/components/SimplicialVisualization3D.tsx`: NEW - Three.js 3D visualization
 - `frontend/src/lab/types/simplicial.ts`: Type updates
 - `frontend/src/lab/hooks/useSimplicialGrowth.ts`: Hook updates
+- `frontend/src/lab/simplicial/__tests__/PachnerMoves.test.ts`: NEW - 12 correctness tests
+- `frontend/src/SimplicialGrowthPage.tsx`: Page updates (dimension switching, 3D viz)
 - `implementation-details/simplicial-integration.md`: Integration documentation
 
 ## Dependencies
@@ -59,8 +62,20 @@ Integrate the new simplicial core with existing code, including migration strate
   - Updated MetricsGrid and TabNavigation with minor improvements
   - Added proper imports and type exports for better module organization
 
+## Progress Tracking (continued)
+- 2026-01-30 03:10:00 IST: T28d completed by Opus 4.5 (review and fix session):
+  - Fixed string-to-number dimension coercion bug (select returns '2' not 2)
+  - Fixed 3D Pachner move parameter mismatches (2-3/3-2/4-1 passed wrong IDs)
+  - Enabled 2D simulation with proper probability defaults on dimension switch
+  - Wired up visualization checkbox handlers
+  - Replaced meaningless curvature metric with Euler characteristic
+  - Created 12 Pachner move correctness tests (all pass)
+  - Created SimplicialVisualization3D.tsx using Three.js with OrbitControls
+  - Fixed PachnerMoveTester 2-tet creation bug (v3+1 without addVertex)
+  - Added diagnostic logging throughout controller and page
+
 ## Issues and Blockers
-- None
+- None (all resolved)
 
 ## Notes
 - Migration should be done incrementally to minimize disruption


### PR DESCRIPTION
## Summary
This PR completes T28d by fixing critical bugs in the simplicial growth simulation, adding comprehensive correctness tests for all Pachner moves, and implementing a Three.js-based 3D visualization for tetrahedral complexes.

## Key Changes

### Bug Fixes
- **Dimension coercion**: Fixed HTML `<select>` returning string `'2'` instead of number `2`, causing strict equality checks to fail and preventing 2D simulation from working
- **3D Pachner move parameters**: Corrected parameter mismatches where wrong simplex IDs were being passed to move functions:
  - `apply2to3` now receives `faceId` (was `edgeId`)
  - `apply3to2` now receives `edgeId` (was `vertexId`)
  - `apply4to1` now receives `vertexId` (was `tetId`)
- **Visualization checkboxes**: Implemented missing onChange handlers for show/hide toggles
- **PachnerMoveTester**: Fixed 2-tetrahedra test case that referenced non-existent vertex ID

### New Features
- **Pachner move tests**: Added 12 unit tests covering all 7 moves (3 in 2D, 4 in 3D) with verification of:
  - Correct simplex count deltas
  - Euler characteristic preservation (topological invariant)
  - Round-trip correctness (move + inverse = identity)
- **3D visualization**: Created `SimplicialVisualization3D.tsx` using Three.js with:
  - Translucent mesh faces with front/back shading
  - Wireframe edges
  - Labeled vertex spheres
  - OrbitControls for interactive rotation/zoom/pan
  - Auto-fit camera to bounding box
- **Live metrics**: Added Euler characteristic, edge count, and face count to metrics panel
- **Dimension-aware rendering**: Automatically switches between 2D canvas and 3D Three.js visualization based on dimension parameter

### Implementation Details
- Dimension changes now automatically swap probability distributions and initial vertex counts (3 for 2D, 4 for 3D)
- Euler characteristic is computed as `V - E + F - T` and verified to be preserved by all Pachner moves
- 3D move selection now validates preconditions (e.g., finding faces shared by exactly 2 tetrahedra for 2-3 moves)
- All 12 tests pass; build is clean

## Files Changed
- Modified: `SimplicialGrowthPage.tsx`, `SimplicialGrowthController.ts`, `SimplicialVisualization.tsx`, `PachnerMoveTester.tsx`
- Created: `SimplicialVisualization3D.tsx`, `PachnerMoves.test.ts`

## Testing
All 12 Pachner move correctness tests pass, verifying topological invariants and simplex count transformations.

https://claude.ai/code/session_01NiAjAaN7EWvZS4qfnvh1WC