### PR TITLE
Fix 3D tet strip rendering and mobile UI responsiveness

### DIFF
--- a/frontend/src/lab/components/SimplicialVisualization3D.tsx
+++ b/frontend/src/lab/components/SimplicialVisualization3D.tsx
@@ -265,30 +265,30 @@ export const SimplicialVisualization3D: React.FC<SimplicialVisualization3DProps>
         className="border border-gray-300 rounded-lg bg-white overflow-hidden max-w-full"
       />
 
-      {/* Info panel */}
-      <div className="absolute top-2 right-2 bg-white bg-opacity-90 p-2 rounded border border-gray-200 text-xs">
+      {/* Info panel - compact on mobile */}
+      <div className="absolute top-1 right-1 sm:top-2 sm:right-2 bg-white bg-opacity-90 p-1 sm:p-2 rounded border border-gray-200 text-[10px] sm:text-xs leading-tight">
         <div className="font-semibold">Simplicial Complex</div>
         <div>Dimension: {complex.topology.dimension}D</div>
         <div>Vertices: {complex.topology.vertices.size}</div>
         <div>Edges: {complex.topology.edges.size}</div>
         <div>Faces: {complex.topology.faces.size}</div>
         <div>Tetrahedra: {complex.topology.tetrahedra.size}</div>
-        <div className="mt-1 pt-1 border-t border-gray-200 text-[10px] text-gray-400">
+        <div className="mt-1 pt-1 border-t border-gray-200 text-[8px] sm:text-[10px] text-gray-400">
           Drag to rotate, scroll to zoom
         </div>
       </div>
 
-      {/* Controls */}
-      <div className="absolute bottom-2 left-2 flex gap-2">
-        <label className="flex items-center text-xs bg-white bg-opacity-90 px-2 py-1 rounded border border-gray-200">
+      {/* Controls - compact on mobile */}
+      <div className="absolute bottom-1 left-1 sm:bottom-2 sm:left-2 flex gap-1 sm:gap-2">
+        <label className="flex items-center text-[10px] sm:text-xs bg-white bg-opacity-90 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded border border-gray-200">
           <input type="checkbox" checked={showVertices} onChange={(e) => setShowVertices(e.target.checked)} className="mr-1" />
           Vertices
         </label>
-        <label className="flex items-center text-xs bg-white bg-opacity-90 px-2 py-1 rounded border border-gray-200">
+        <label className="flex items-center text-[10px] sm:text-xs bg-white bg-opacity-90 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded border border-gray-200">
           <input type="checkbox" checked={showEdges} onChange={(e) => setShowEdges(e.target.checked)} className="mr-1" />
           Edges
         </label>
-        <label className="flex items-center text-xs bg-white bg-opacity-90 px-2 py-1 rounded border border-gray-200">
+        <label className="flex items-center text-[10px] sm:text-xs bg-white bg-opacity-90 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded border border-gray-200">
           <input type="checkbox" checked={showFaces} onChange={(e) => setShowFaces(e.target.checked)} className="mr-1" />
           Faces
         </label>

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,7 +1,7 @@
 # Active Context
 
 *Created: 2025-08-20 08:31:32 IST*
-*Last Updated: 2026-01-30 17:22:00 IST*
+*Last Updated: 2026-01-30 19:45:00 IST*
 
 ## Current Focus
 **Task**: T30b Simplicial Boundary Conditions & 3D Tet Strip Fix
@@ -36,7 +36,7 @@ T31 completed: Comprehensive mobile UI overhaul including bottom icon navigation
 - Added BoundaryConstraintMode type and extended BoundaryGrowthParams with boundary constraints
 - Implemented getBottomAndSideBoundaries2D/3D() for automatic boundary identification
 - Added frozen boundary filtering in BoundaryGrowthController.step() for both 2D and 3D
-- Fixed createTetStripGeometry() to generate non-degenerate tets in two parallel layers
+- Rewrote createTetStripGeometry() from scratch with cube-inscribed approach for proper 3D rendering from default camera angle
 - Updated createTetStripTopology() to match new geometry (2*(n+1) vertices)
 - Added isBoundaryFrozen() helper for efficient constraint checking
 - All acceptance criteria met (7/9), UI/visualization deferred to T30c

--- a/memory-bank/sessions/2026-01-30-night-3.md
+++ b/memory-bank/sessions/2026-01-30-night-3.md
@@ -25,17 +25,17 @@ T30b: Simplicial Boundary Conditions & 3D Tet Strip Fix
 
 **Root Cause**: `createTetStripGeometry()` placed bottom layer vertices colinearly (same y, same z) and offset top layer primarily in z. Since the default Three.js camera looks down the z-axis from (0,0,300), the z-separation was invisible, making the strip appear flat/2D.
 
-**Fix**: Rewrote geometry to use cube-inscribed approach (s=scale/√3) with:
-- Bottom layer: zigzag y positions (±s), flat z
-- Top layer: opposite zigzag y (∓s), alternating z offsets (±1.5s)
-- Both layers share same x positions with edgeSpacing = 2s
+**Fix (attempt 1)**: Both layers zigzagged symmetrically — triple product = 0, still coplanar.
 
-**Contrast with growth**: Growth code (`computeCandidatePosition3D`) places new vertices along outward face normals, naturally producing 3D structures visible from any angle.
+**Fix (attempt 2 — final)**: Bottom layer zigzags y at z=0, top layer has opposite y zigzag at constant z=1.5s. Triple product = 3s²dx > 0, proven non-coplanar. Each tet projects as a rhombus from z-camera with visible 3D depth from lighting.
+
+**Mobile legend fix**: Info panel and checkbox controls now use text-[10px] on mobile (< sm breakpoint), with tighter padding (p-1, px-1.5 py-0.5). Desktop unchanged via sm: responsive classes.
 
 ## Critical Files
 
 **Modified Files** (session):
-- `frontend/src/lab/simplicial/geometry/types.ts` — createTetStripGeometry rewrite
+- `frontend/src/lab/simplicial/geometry/types.ts` — createTetStripGeometry rewrite (2 iterations)
+- `frontend/src/lab/components/SimplicialVisualization3D.tsx` — mobile-responsive legend sizing
 - `memory-bank/tasks/T30b.md` — progress update
 - `memory-bank/activeContext.md` — context update
 

--- a/memory-bank/sessions/2026-01-30-night-3.md
+++ b/memory-bank/sessions/2026-01-30-night-3.md
@@ -1,0 +1,44 @@
+# Session 2026-01-30 - Night 3
+*Created: 2026-01-30 19:40:00 IST*
+*Last Updated: 2026-01-30 19:45:00 IST*
+
+## Focus Task
+T30b: Simplicial Boundary Conditions & 3D Tet Strip Fix
+
+**Status**: 🔄 IN PROGRESS
+
+## Active Tasks
+### T30b: 3D Tet Strip Geometry Rewrite
+**Status**: 🔄 IN PROGRESS
+**Priority**: HIGH
+
+**Progress**:
+1. ✅ Diagnosed root cause of flat tet strip rendering
+2. ✅ Rewrote createTetStripGeometry() from scratch
+3. ✅ Added diagnostic logging
+4. ✅ Build verification (pnpm build clean)
+5. ✅ Memory bank updates
+
+## Session Summary
+
+**Objective**: Fix tetrahedron strip initial topology rendering as 2D instead of 3D
+
+**Root Cause**: `createTetStripGeometry()` placed bottom layer vertices colinearly (same y, same z) and offset top layer primarily in z. Since the default Three.js camera looks down the z-axis from (0,0,300), the z-separation was invisible, making the strip appear flat/2D.
+
+**Fix**: Rewrote geometry to use cube-inscribed approach (s=scale/√3) with:
+- Bottom layer: zigzag y positions (±s), flat z
+- Top layer: opposite zigzag y (∓s), alternating z offsets (±1.5s)
+- Both layers share same x positions with edgeSpacing = 2s
+
+**Contrast with growth**: Growth code (`computeCandidatePosition3D`) places new vertices along outward face normals, naturally producing 3D structures visible from any angle.
+
+## Critical Files
+
+**Modified Files** (session):
+- `frontend/src/lab/simplicial/geometry/types.ts` — createTetStripGeometry rewrite
+- `memory-bank/tasks/T30b.md` — progress update
+- `memory-bank/activeContext.md` — context update
+
+## Session Outcome
+
+**Status**: ✅ SESSION COMPLETE

--- a/memory-bank/tasks/T30b.md
+++ b/memory-bank/tasks/T30b.md
@@ -1,6 +1,6 @@
 # T30b: Simplicial Boundary Conditions & 3D Tet Strip Fix
 *Created: 2026-01-30 08:15:03 IST*
-*Last Updated: 2026-01-30 08:15:03 IST*
+*Last Updated: 2026-01-30 19:40:00 IST*
 
 ## Task Information
 **Title:** Simplicial Boundary Conditions & 3D Tet Strip Fix
@@ -47,6 +47,7 @@ See: `memory-bank/implementation-details/simplicial-boundary-conditions.md`
 - 2026-01-30 08:15 IST: Task created, implementation doc written
 - 2026-01-30 08:18 IST: Core implementation complete - all acceptance criteria met, code builds clean
 - 2026-01-30 18:38 IST: UI controls implemented (boundary condition mode selector, custom frozen boundary picker, frozen boundary count display)
+- 2026-01-30 19:40 IST: Rewrote createTetStripGeometry() from scratch — old version placed bottom layer colinear (same y,z) and top layer offset mainly in z (invisible from default camera). New version uses cube-inscribed approach (s=scale/√3), zigzag y for both layers, alternating z offsets for top layer, producing proper 3D tetrahedra visible from default camera at (0,0,300)
 
 ## Issues and Blockers
 - None

--- a/memory-bank/tasks/T30b.md
+++ b/memory-bank/tasks/T30b.md
@@ -47,7 +47,8 @@ See: `memory-bank/implementation-details/simplicial-boundary-conditions.md`
 - 2026-01-30 08:15 IST: Task created, implementation doc written
 - 2026-01-30 08:18 IST: Core implementation complete - all acceptance criteria met, code builds clean
 - 2026-01-30 18:38 IST: UI controls implemented (boundary condition mode selector, custom frozen boundary picker, frozen boundary count display)
-- 2026-01-30 19:40 IST: Rewrote createTetStripGeometry() from scratch — old version placed bottom layer colinear (same y,z) and top layer offset mainly in z (invisible from default camera). New version uses cube-inscribed approach (s=scale/√3), zigzag y for both layers, alternating z offsets for top layer, producing proper 3D tetrahedra visible from default camera at (0,0,300)
+- 2026-01-30 19:40 IST: First rewrite of createTetStripGeometry() — still had coplanar vertices (triple product = 0)
+- 2026-01-30 20:15 IST: Second rewrite — bottom zigzag y at z=0, top opposite zigzag y at constant z=1.5s. Triple product = 3s²dx ≠ 0 (proven non-coplanar). Also made info panel and checkbox legend compact on mobile (text-[10px], sm: breakpoint)
 
 ## Issues and Blockers
 - None


### PR DESCRIPTION
## Summary
This PR fixes the tetrahedron strip visualization appearing flat/2D instead of 3D, and improves mobile UI responsiveness for the info panel and controls.

## Key Changes

### 3D Tet Strip Geometry Fix
- **Root cause**: The original `createTetStripGeometry()` placed all bottom layer vertices colinearly with identical y and z coordinates, and offset the top layer primarily in z. Since the default Three.js camera views along the z-axis, this z-separation was invisible, making the strip appear 2D.
- **Solution**: Completely rewrote the geometry generation with a cube-inscribed approach:
  - Bottom layer (vertices 0..n): zigzag pattern in y-coordinate at z=centerZ
  - Top layer (vertices n+1..2n+1): opposite zigzag pattern in y-coordinate at constant z=centerZ+1.5s
  - Each tetrahedron (i, i+1, n+1+i, n+2+i) now has proven non-zero volume (triple product = 3s²dx ≠ 0)
  - Vertices now project as visible rhombuses with proper 3D depth from lighting
- **Added diagnostic logging**: Console debug output shows tet count, vertex count, scale factor, and volume per tetrahedron

### Mobile UI Responsiveness
- **Info panel**: Reduced padding (p-1 on mobile, sm:p-2 on desktop) and text size (text-[10px] on mobile, sm:text-xs on desktop)
- **Control checkboxes**: Tighter spacing (gap-1 on mobile, sm:gap-2 on desktop) and responsive padding (px-1.5 py-0.5 on mobile, sm:px-2 sm:py-1 on desktop)
- **Positioning**: Adjusted offsets (top-1/right-1 on mobile, sm:top-2/sm:right-2 on desktop) for better mobile screen real estate

## Implementation Details
- Scale factor `s = scale / √3` ensures proper geometric relationships
- Horizontal spacing `dx = 2s` between consecutive vertices
- Z-offset for top layer: `1.5s` provides sufficient separation for 3D visibility
- All responsive classes use Tailwind's `sm:` breakpoint for mobile-first design
- Geometry maintains mathematical correctness: non-degenerate tetrahedra with positive volume

## Testing
- Build verification: `pnpm build` completes cleanly
- Geometry validated with mathematical proof of non-coplanarity
- Mobile layout tested with responsive breakpoints

https://claude.ai/code/session_01VudyPT5RSRm6bDh1h2yZmL