### PR TITLE
T33: Fix boundary growth panel size, symmetric simplices, and boundary conditions

### DIFF
--- a/frontend/src/SimplicialGrowthPage.tsx
+++ b/frontend/src/SimplicialGrowthPage.tsx
@@ -256,7 +256,7 @@ const BoundaryGrowthTab: React.FC = () => {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [params, setParams] = React.useState<BoundaryGrowthParams>({
     dimension: 2, maxSteps: 200, growthScale: 80, tentProbability: 0.3,
-    preventOverlap: false, initialState: 'single-simplex', stripLength: 8,
+    preventOverlap: false, symmetricSimplices: true, initialState: 'single-simplex', stripLength: 8,
     boundaryConstraints: {
       mode: 'none',
       customFrozenElementIds: new Set<number>(),
@@ -384,6 +384,9 @@ const BoundaryGrowthTab: React.FC = () => {
         { label: 'Prevent Overlap', type: 'checkbox' as const, value: params.preventOverlap,
           onChange: (val: boolean) => handleParamChange('preventOverlap', val),
           hint: 'Reject overlapping simplices' },
+        { label: 'Symmetric Simplices', type: 'checkbox' as const, value: params.symmetricSimplices,
+          onChange: (val: boolean) => handleParamChange('symmetricSimplices', val),
+          hint: 'Enforce equilateral/regular shape on all new simplices' },
       ],
     },
     {
@@ -413,11 +416,11 @@ const BoundaryGrowthTab: React.FC = () => {
         <div className="bg-white border border-gray-200 rounded-lg p-3 sm:p-6">
           <h2 className="text-lg sm:text-xl font-semibold mb-3">Visualization</h2>
           {simulation.currentState ? (
-            <div>
+            <div className="max-w-2xl">
               {params.dimension === 3 ? (
-                <SimplicialVisualization3D complex={simulation.currentState.complex} width={700} height={500} responsive />
+                <SimplicialVisualization3D complex={simulation.currentState.complex} width={600} height={400} responsive />
               ) : (
-                <SimplicialVisualization complex={simulation.currentState.complex} width={700} height={500} responsive />
+                <SimplicialVisualization complex={simulation.currentState.complex} width={600} height={400} responsive />
               )}
               {simulation.currentState.frozenBoundaryElements.size > 0 && (
                 <div className="mt-2 text-sm text-gray-600">

--- a/frontend/src/lab/types/simplicial.ts
+++ b/frontend/src/lab/types/simplicial.ts
@@ -65,6 +65,7 @@ export interface BoundaryGrowthParams {
   growthScale: number;
   tentProbability: number; // 0-1, rest is glue probability
   preventOverlap: boolean;
+  symmetricSimplices: boolean; // T33: enforce equilateral/regular simplex shape on glue
   initialState: InitialStateType;
   stripLength: number; // number of triangles/tets in strip (3-20)
   boundaryConstraints?: {

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,16 +1,19 @@
 # Active Context
 
 *Created: 2025-08-20 08:31:32 IST*
-*Last Updated: 2026-01-30 19:45:00 IST*
+*Last Updated: 2026-02-16 05:27:33 IST*
 
 ## Current Focus
-**Task**: T32 Python Backend Environment Setup and Documentation
-**Status**: 🔄 IN PROGRESS - Documentation created, task file and registry updated
+**Task**: T33 - Boundary Growth: Panel Size, Symmetric Simplices, Boundary Conditions Fix
+**Status**: ✅ COMPLETED - All three issues fixed, built and pushed to claude/boundary-growth-simplicial-egRHn
 
-**Recent Completion**: T30b - Simplicial Boundary Conditions & 3D Tet Strip Fix ✅ COMPLETED
+**Recent Completion**: T33 - Boundary Growth Visualization Fixes ✅ COMPLETED
 
 ## Immediate Context
-T32 documentation completed - Created comprehensive Python backend environment setup guide, updated Vercel deployment plan with Python environment section, added task to registry with proper schema compliance. All memory bank files updated following v6.12 protocol.
+T33 completed: Fixed three issues in Simplicial Growth -> Boundary Growth tab:
+1. Panel size: max-w-2xl wrapper + canvas reduced to 600x400
+2. Symmetric simplices (default on): equilateral placement via edgeLen*sqrt(3)/2 for 2D; regular tet via avgEdgeLen*sqrt(2/3) for 3D; UI toggle checkbox added
+3. Boundary conditions: minY→maxY axis inversion fix for screen y-down; relative 2% threshold; dynamic frozen set recomputed per step() for bottom-and-sides mode
 
 T31 completed: Comprehensive mobile UI overhaul including bottom icon navigation bar with hamburger overflow menu, compact MetricsGrid (3-col mobile), slide-in parameter drawer, simulation controls repositioned below visualization, responsive canvas sizing via ResizeObserver, compact visualization info panel, and memory bank viewer scroll fixes.
 

--- a/memory-bank/edits/2026-02-16/052733-T33-boundary-growth-fixes.md
+++ b/memory-bank/edits/2026-02-16/052733-T33-boundary-growth-fixes.md
@@ -1,0 +1,13 @@
+# Edit History
+*Created: 2026-02-16 05:27:33 IST*
+*Last Updated: 2026-02-16 05:27:33 IST*
+
+### 2026-02-16
+
+#### 05:27:33 IST - T33: Boundary Growth Panel, Symmetric Simplices, Boundary Conditions Fix
+
+- Modified `frontend/src/lab/types/simplicial.ts` - Added symmetricSimplices boolean field to BoundaryGrowthParams interface
+- Modified `frontend/src/lab/simplicial/operations/BoundaryGrowth.ts` - Fixed getBottomAndSideBoundaries2D axis inversion (minY→maxY for screen y-down); replaced hard-coded 0.1 threshold with relative 2% of x-span; added symmetric param to glueTriangle2D (equilateral: edgeLen*sqrt(3)/2) and glueTetrahedron3D (regular: avgEdgeLen*sqrt(2/3))
+- Modified `frontend/src/lab/controllers/BoundaryGrowthController.ts` - Dynamic frozen set recomputed each step() for bottom-and-sides mode; updated computeCandidatePosition2D/3D to respect symmetric flag; passed symmetric to all glue calls
+- Modified `frontend/src/SimplicialGrowthPage.tsx` - BoundaryGrowthTab visualization wrapped in max-w-2xl container, canvas reduced from 700x500 to 600x400; symmetricSimplices default true; Symmetric Simplices checkbox added to parameters panel
+- Created `memory-bank/tasks/T33.md` - Task file for T33 fixes

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -1,7 +1,7 @@
 # Task Registry
 
 *Created: 2025-08-20 08:31:32 IST*
-*Last Updated: 2026-02-09 20:51:40 IST*
+*Last Updated: 2026-02-16 05:27:33 IST*
 
 ## Active Tasks
 
@@ -63,6 +63,7 @@
 | T30b | Simplicial Boundary Conditions & 3D Tet Strip Fix | 🔄 IN PROGRESS | HIGH | 2026-01-30 | T30, T30a | [Details](tasks/T30b.md) |
 | T31 | Mobile UI Responsiveness and Design | ✅ COMPLETED | HIGH | 2026-01-30 | T27, T29a, T30a | [Details](tasks/T31.md) |
 | T32 | Python Backend Environment Setup and Documentation | 🔄 IN PROGRESS | MEDIUM | 2026-02-09 | - | [Details](tasks/T32.md) |
+| T33 | Boundary Growth: Panel Size, Symmetric Simplices, Boundary Conditions Fix | ✅ COMPLETED | HIGH | 2026-02-16 | T30, T30b | [Details](tasks/T33.md) |
 
 ## Task Details
 

--- a/memory-bank/tasks/T33.md
+++ b/memory-bank/tasks/T33.md
@@ -1,0 +1,46 @@
+ ---
+ source_branch: claude/boundary-growth-simplicial-egRHn
+ source_commit: bb309bebb1191079f15d3f2b9eaf8b15f8c433c6
+ ---
+
+# T33: Boundary Growth - Panel Size, Symmetric Simplices, Boundary Conditions Fix
+*Created: 2026-02-16 05:27:33 IST*
+*Last Updated: 2026-02-16 05:27:33 IST*
+
+**Description**: Fix three issues in the Simplicial Growth -> Boundary Growth tab: (1) visualization panel too large on desktop, (2) simplices of variable size/shape, (3) bottom-and-sides boundary condition growing in wrong direction.
+**Status**: ✅ COMPLETED
+**Priority**: HIGH
+**Started**: 2026-02-16
+**Last Active**: 2026-02-16 05:27:33 IST
+**Dependencies**: T30, T30b
+
+## Completion Criteria
+- ✅ Panel max-w-2xl applied, canvas reduced to 600x400 in BoundaryGrowthTab
+- ✅ symmetricSimplices param added with default true; equilateral/regular placement for 2D and 3D glue
+- ✅ getBottomAndSideBoundaries2D axis inversion fixed (minY → maxY for screen y-down)
+- ✅ Relative threshold (2% of x-span) replaces hard-coded 0.1px
+- ✅ Frozen set dynamically recomputed each step in controller
+- ✅ Build passes cleanly
+
+## Related Files
+- `frontend/src/lab/types/simplicial.ts` - Added symmetricSimplices field to BoundaryGrowthParams
+- `frontend/src/lab/simplicial/operations/BoundaryGrowth.ts` - Fixed axis inversion, relative threshold, symmetric glue params
+- `frontend/src/lab/controllers/BoundaryGrowthController.ts` - Dynamic frozen set, symmetric flag forwarding
+- `frontend/src/SimplicialGrowthPage.tsx` - Panel size wrapper, symmetricSimplices default + toggle UI
+
+## Progress
+1. ✅ Analyzed all three issues
+2. ✅ Added symmetricSimplices to BoundaryGrowthParams type
+3. ✅ Fixed getBottomAndSideBoundaries2D (maxY + relative threshold)
+4. ✅ Added symmetric parameter to glueTriangle2D and glueTetrahedron3D
+5. ✅ Updated computeCandidatePosition2D/3D in controller for symmetric mode
+6. ✅ Dynamic frozen set recomputation in step()
+7. ✅ Panel size fix + toggle checkbox in UI
+8. ✅ Build verified, committed and pushed
+
+## Context
+- Screen y-axis increases downward: visual bottom = maxY, not minY
+- 3D bottom detection uses minZ (z-up convention for tet strips) - no fix needed
+- Equilateral triangle apex height from edge midpoint: edgeLen * sqrt(3) / 2
+- Regular tetrahedron apex height from face centroid: avgEdgeLen * sqrt(2/3)
+- Frozen set was static (computed once at init); now recomputed each step for bottom-and-sides mode


### PR DESCRIPTION
## Summary
Fixes three issues in the Simplicial Growth → Boundary Growth tab: oversized visualization panel on desktop, variable-sized simplices, and incorrect boundary condition detection.

## Key Changes

**Panel Size & UI**
- Wrapped BoundaryGrowthTab visualization in `max-w-2xl` container
- Reduced canvas dimensions from 700×500 to 600×400 for better desktop layout
- Added "Symmetric Simplices" checkbox to parameters panel (default: enabled)

**Symmetric Simplices (T33)**
- Added `symmetric` parameter to `glueTriangle2D()` and `glueTetrahedron3D()`
- When enabled, enforces equilateral/regular simplex placement:
  - **2D**: New vertex placed at edge midpoint + normal × (edgeLen × √3/2)
  - **3D**: New vertex placed at face centroid + normal × (avgEdgeLen × √(2/3))
- Updated `BoundaryGrowthController` to compute candidate positions respecting symmetric flag
- Added debug logging for displacement calculations

**Boundary Conditions Fix**
- Fixed `getBottomAndSideBoundaries2D()` axis inversion: changed `minY` → `maxY` (screen y-axis increases downward)
- Replaced hard-coded 0.1px threshold with relative threshold: `max(0.5, xSpan × 0.02)`
- Added dynamic frozen set recomputation in `BoundaryGrowthController.step()` for bottom-and-sides mode (was previously computed once at initialization)

**Type Updates**
- Added `symmetricSimplices: boolean` field to `BoundaryGrowthParams` interface

## Implementation Details
- Equilateral triangle height formula: edge length × √3/2 (from midpoint perpendicular)
- Regular tetrahedron height formula: average edge length × √(2/3) (from face centroid perpendicular)
- Relative threshold adapts to coordinate scale variations across different models
- Frozen boundary elements now recomputed each step to handle dynamic geometry changes

https://claude.ai/code/session_01Jf8czCxnEuKoqB2WpcdTUc